### PR TITLE
feat(observability): add Kubernetes monitoring stack

### DIFF
--- a/cluster/apps/observability/README.md
+++ b/cluster/apps/observability/README.md
@@ -1,0 +1,18 @@
+# Observability
+
+This stack is the Kubernetes-first observability migration target.
+
+## Included now
+
+- `kube-prometheus-stack`: Prometheus, Alertmanager, kube-state-metrics, node-exporter, and bundled Grafana.
+- `loki`: single-binary Loki with filesystem-backed persistence for short-retention cluster logs.
+- `promtail`: DaemonSet for Kubernetes/containerd pod logs from `/var/log/pods` and `/var/log/containers`.
+- `unpoller`: existing UniFi metrics exporter, scraped by Prometheus through an additional ServiceMonitor rendered by `kube-prometheus-stack`.
+
+## Intentionally deferred
+
+- Docker host log scraping. Some apps still run on the Docker host, but the *arr/Plex/etc workloads are expected to move into Kubernetes later. Start with Kubernetes-native logs and add host log collection only if it is still needed after that migration.
+- Gatus/blackbox probes for uptime checks.
+- SMART/disk telemetry via smartctl-exporter.
+- Grafana Operator/dashboard CRDs. The bundled Grafana is simpler for the first migration pass.
+- VictoriaLogs/Fluent Bit. chr1sd's stack uses this pattern well; consider it later if Loki/Promtail becomes too heavy or Promtail deprecation becomes painful.

--- a/cluster/apps/observability/kube-prometheus-stack/grafana-admin-secret.sops.yaml
+++ b/cluster/apps/observability/kube-prometheus-stack/grafana-admin-secret.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: grafana-admin-secret
+    namespace: observability
+stringData:
+    admin-user: ENC[AES256_GCM,data:Ib41wes=,iv:F5cOevQ2srG6SKWlv1v67Tanra25tKVoEMvhQW1kOEw=,tag:Y8kCkoRjwO/lYLEJtGUCag==,type:str]
+    admin-password: ENC[AES256_GCM,data:n4G6NUXpAPBiWcgXn/70pJu2Owd2J+T+kSaY39IdEO0=,iv:YkxoKj7RsPXKTQpCPOA+//KGgUl4DQ/uhuSlEP4dRX0=,tag:W/3aE4XhN0iFoHu0F4olgg==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvb0VOTSswbWFkVnZDc1R3
+            cFpqMmxtM3pQRG0wTndidG5lVHhIMzRaeHdNCmMxSlZubU5rVWNKaTd1TFpQT0Fk
+            c1psNFV4aUlhYktoVnVEMU13SEJ3clUKLS0tIG1zejE4R2g4S09FZTVyazlEa0ZP
+            cG0yakdUd2g1U0F6dFpxWjlQWDFmODAKffpvyLP1QwHnbxno4xGxv427G8zkf4vO
+            6FsvZuT7btIGhJrlejevHyqVk5CpWLUJwh5/FJaX7/jeybrOMmO1Mw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age16vs9crdp7cxwjtlqu5l83a3pgdah9eau3afrhx7qyzkhag7avq0spf6rxp
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-15T21:56:39Z"
+    mac: ENC[AES256_GCM,data:xUdzxXpmeTk3ykGKnUb4bV3H5c4dybGNlEk0GoH9fAs7Xh8O7Rv1Wa7fPlb06K/e2e+a64AYS4hGg+olV5jpZPjnaWDLo+N+ujdNmzmFnXBRvUKlRypRGYdvRPkuqb6gUzaB2HWz7FyXp3Y6/taZiC+/s/2gUI0ILBzowIRmKN4=,iv:bCsZf08uMkoCuOMpRaSb3L4VcM/Z4ZJrQD2mXEwAxLg=,tag:ntzgLVs6sdJ2+hiVUD0VNA==,type:str]
+    version: 3.13.0

--- a/cluster/apps/observability/kube-prometheus-stack/helm-release.yaml
+++ b/cluster/apps/observability/kube-prometheus-stack/helm-release.yaml
@@ -1,0 +1,176 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kube-prometheus-stack
+  namespace: observability
+spec:
+  interval: 15m
+  chart:
+    spec:
+      # renovate: registryUrl=https://prometheus-community.github.io/helm-charts
+      chart: kube-prometheus-stack
+      version: 85.1.1
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus-community-charts
+        namespace: flux-system
+      interval: 15m
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 5
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 5
+  values:
+    cleanPrometheusOperatorObjectNames: true
+    defaultRules:
+      create: true
+      rules:
+        etcd: false
+        kubeControllerManager: false
+        kubeProxy: false
+        kubeScheduler: false
+    alertmanager:
+      ingress:
+        enabled: true
+        ingressClassName: traefik
+        annotations:
+          cert-manager.io/cluster-issuer: letsencrypt-production
+          hajimari.io/enable: "true"
+          hajimari.io/icon: alert
+          hajimari.io/group: observability
+          traefik.ingress.kubernetes.io/router.entrypoints: websecure
+        hosts:
+          - alertmanager.k8s.${SECRET_DOMAIN}
+        tls:
+          - hosts:
+              - alertmanager.k8s.${SECRET_DOMAIN}
+            secretName: alertmanager-tls
+      alertmanagerSpec:
+        retention: 120h
+        storage:
+          volumeClaimTemplate:
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 2Gi
+    grafana:
+      enabled: true
+      defaultDashboardsTimezone: ${TIMEZONE}
+      admin:
+        existingSecret: grafana-admin-secret
+        userKey: admin-user
+        passwordKey: admin-password
+      ingress:
+        enabled: true
+        ingressClassName: traefik
+        annotations:
+          cert-manager.io/cluster-issuer: letsencrypt-production
+          hajimari.io/enable: "true"
+          hajimari.io/icon: grafana
+          hajimari.io/group: observability
+          traefik.ingress.kubernetes.io/router.entrypoints: websecure
+        hosts:
+          - grafana.k8s.${SECRET_DOMAIN}
+        tls:
+          - hosts:
+              - grafana.k8s.${SECRET_DOMAIN}
+            secretName: grafana-tls
+      sidecar:
+        dashboards:
+          enabled: true
+          searchNamespace: ALL
+        datasources:
+          enabled: true
+          searchNamespace: ALL
+      additionalDataSources:
+        - name: Loki
+          type: loki
+          access: proxy
+          url: http://loki:3100
+          jsonData:
+            maxLines: 1000
+      persistence:
+        enabled: true
+        size: 5Gi
+      resources:
+        requests:
+          cpu: 50m
+          memory: 256Mi
+        limits:
+          memory: 512Mi
+    kubeApiServer:
+      enabled: true
+    kubeControllerManager:
+      enabled: false
+    kubeEtcd:
+      enabled: false
+    kubeProxy:
+      enabled: false
+    kubeScheduler:
+      enabled: false
+    kubelet:
+      enabled: true
+      serviceMonitor:
+        cAdvisor: true
+    prometheus:
+      ingress:
+        enabled: true
+        ingressClassName: traefik
+        annotations:
+          cert-manager.io/cluster-issuer: letsencrypt-production
+          hajimari.io/enable: "true"
+          hajimari.io/icon: chart-line
+          hajimari.io/group: observability
+          traefik.ingress.kubernetes.io/router.entrypoints: websecure
+        hosts:
+          - prometheus.k8s.${SECRET_DOMAIN}
+        tls:
+          - hosts:
+              - prometheus.k8s.${SECRET_DOMAIN}
+            secretName: prometheus-tls
+      prometheusSpec:
+        retention: 14d
+        retentionSize: 8GB
+        scrapeInterval: 1m
+        evaluationInterval: 1m
+        serviceMonitorSelectorNilUsesHelmValues: false
+        podMonitorSelectorNilUsesHelmValues: false
+        probeSelectorNilUsesHelmValues: false
+        ruleSelectorNilUsesHelmValues: false
+        storageSpec:
+          volumeClaimTemplate:
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 10Gi
+      additionalServiceMonitors:
+        - name: unpoller
+          selector:
+            matchLabels:
+              app.kubernetes.io/service: unpoller
+          namespaceSelector:
+            matchNames:
+              - observability
+          endpoints:
+            - port: http
+              path: /metrics
+              interval: 1m
+    prometheusOperator:
+      admissionWebhooks:
+        certManager:
+          enabled: true
+        patch:
+          enabled: false
+    prometheus-node-exporter:
+      prometheus:
+        monitor:
+          enabled: true

--- a/cluster/apps/observability/kube-prometheus-stack/kustomization.yaml
+++ b/cluster/apps/observability/kube-prometheus-stack/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - grafana-admin-secret.sops.yaml
+  - helm-release.yaml

--- a/cluster/apps/observability/kustomization.yaml
+++ b/cluster/apps/observability/kustomization.yaml
@@ -4,3 +4,6 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - unpoller
+  - kube-prometheus-stack
+  - loki
+  - promtail

--- a/cluster/apps/observability/loki/helm-release.yaml
+++ b/cluster/apps/observability/loki/helm-release.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: loki
+  namespace: observability
+spec:
+  interval: 15m
+  chart:
+    spec:
+      # renovate: registryUrl=https://grafana.github.io/helm-charts
+      chart: loki
+      version: 7.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: grafana-charts
+        namespace: flux-system
+      interval: 15m
+  install:
+    remediation:
+      retries: 5
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 5
+  values:
+    deploymentMode: SingleBinary
+    loki:
+      auth_enabled: false
+      commonConfig:
+        replication_factor: 1
+      schemaConfig:
+        configs:
+          - from: "2024-01-01"
+            store: tsdb
+            object_store: filesystem
+            schema: v13
+            index:
+              prefix: index_
+              period: 24h
+      storage:
+        type: filesystem
+      limits_config:
+        retention_period: 168h
+      compactor:
+        retention_enabled: true
+    singleBinary:
+      replicas: 1
+      persistence:
+        enabled: true
+        size: 10Gi
+    read:
+      replicas: 0
+    write:
+      replicas: 0
+    backend:
+      replicas: 0
+    chunksCache:
+      enabled: false
+    resultsCache:
+      enabled: false
+    lokiCanary:
+      enabled: false
+    test:
+      enabled: false

--- a/cluster/apps/observability/loki/kustomization.yaml
+++ b/cluster/apps/observability/loki/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helm-release.yaml

--- a/cluster/apps/observability/promtail/helm-release.yaml
+++ b/cluster/apps/observability/promtail/helm-release.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: promtail
+  namespace: observability
+spec:
+  interval: 15m
+  dependsOn:
+    - name: kube-prometheus-stack
+      namespace: observability
+    - name: loki
+      namespace: observability
+  chart:
+    spec:
+      # renovate: registryUrl=https://grafana.github.io/helm-charts
+      chart: promtail
+      version: 6.17.1
+      sourceRef:
+        kind: HelmRepository
+        name: grafana-charts
+        namespace: flux-system
+      interval: 15m
+  install:
+    remediation:
+      retries: 5
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 5
+  values:
+    config:
+      clients:
+        - url: http://loki:3100/loki/api/v1/push
+      snippets:
+        pipelineStages:
+          - cri: {}
+    serviceMonitor:
+      enabled: true
+    tolerations:
+      - operator: Exists
+    resources:
+      requests:
+        cpu: 25m
+        memory: 64Mi
+      limits:
+        memory: 128Mi

--- a/cluster/apps/observability/promtail/kustomization.yaml
+++ b/cluster/apps/observability/promtail/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helm-release.yaml


### PR DESCRIPTION
## Summary
- add kube-prometheus-stack with bundled Grafana, Prometheus, Alertmanager, node-exporter, and kube-state-metrics
- add Loki single-binary storage plus Promtail for Kubernetes/containerd pod logs
- wire existing unpoller metrics into Prometheus via kube-prometheus-stack additionalServiceMonitors
- document intentionally deferred pieces: Docker host logs, Gatus/blackbox, SMART metrics, Grafana Operator, VictoriaLogs/Fluent Bit

## Validation
- kubectl kustomize cluster/apps/observability
- helm template kube-prometheus-stack 85.1.1 with extracted values
- helm template loki 7.0.0 with extracted values
- helm template promtail 6.17.1 with extracted values

Note: promtail chart renders with an upstream deprecation warning; this is acceptable for the first migration pass, and the README calls out VictoriaLogs/Fluent Bit or Alloy as future improvements.