### PR TITLE
fix(observability): configure Loki compactor delete store

### DIFF
--- a/cluster/apps/observability/README.md
+++ b/cluster/apps/observability/README.md
@@ -15,4 +15,5 @@ This stack is the Kubernetes-first observability migration target.
 - Gatus/blackbox probes for uptime checks.
 - SMART/disk telemetry via smartctl-exporter.
 - Grafana Operator/dashboard CRDs. The bundled Grafana is simpler for the first migration pass.
-- VictoriaLogs/Fluent Bit. chr1sd's stack uses this pattern well; consider it later if Loki/Promtail becomes too heavy or Promtail deprecation becomes painful.
+- Grafana Alloy replacing Promtail. Promtail is in LTS and should be swapped for Alloy soon, but Promtail is the smaller first pass for getting Loki ingestion working.
+- VictoriaLogs/Fluent Bit. chr1sd's stack uses this pattern well; consider it later if Loki/Alloy becomes too heavy.

--- a/cluster/apps/observability/loki/helm-release.yaml
+++ b/cluster/apps/observability/loki/helm-release.yaml
@@ -44,6 +44,7 @@ spec:
         retention_period: 168h
       compactor:
         retention_enabled: true
+        delete_request_store: filesystem
     singleBinary:
       replicas: 1
       persistence:


### PR DESCRIPTION
## Summary
- configure Loki compactor `delete_request_store: filesystem` so retention-enabled single-binary Loki starts cleanly
- document Grafana Alloy as the intended near-future Promtail replacement

## Validation
- `helm template loki grafana/loki --version 7.0.0 --namespace observability -f /tmp/loki-values-fix.yaml`
- `kubectl kustomize cluster/apps/observability`
