### PR TITLE
chore(flux): migrate manifests to stable APIs

### DIFF
--- a/cluster/base/apps.yaml
+++ b/cluster/base/apps.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: apps

--- a/cluster/base/core.yaml
+++ b/cluster/base/core.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: core

--- a/cluster/base/crds.yaml
+++ b/cluster/base/crds.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: crds

--- a/cluster/base/flux-system/charts/helm/authentik-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/authentik-charts.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: authentik-charts

--- a/cluster/base/flux-system/charts/helm/bitnami-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/bitnami-charts.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: bitnami-charts

--- a/cluster/base/flux-system/charts/helm/bjw-s-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/bjw-s-charts.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: bjw-s-charts

--- a/cluster/base/flux-system/charts/helm/deliveryhero-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/deliveryhero-charts.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: deliveryhero-charts

--- a/cluster/base/flux-system/charts/helm/descheduler-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/descheduler-charts.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: descheduler-charts

--- a/cluster/base/flux-system/charts/helm/emberstack-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/emberstack-charts.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: emberstack-charts

--- a/cluster/base/flux-system/charts/helm/external-dns-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/external-dns-charts.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: external-dns-charts

--- a/cluster/base/flux-system/charts/helm/grafana-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/grafana-charts.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: grafana-charts

--- a/cluster/base/flux-system/charts/helm/hajimari-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/hajimari-charts.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: hajimari-charts

--- a/cluster/base/flux-system/charts/helm/infracloudio-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/infracloudio-charts.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: infracloudio-charts

--- a/cluster/base/flux-system/charts/helm/intel-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/intel-charts.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: intel-charts

--- a/cluster/base/flux-system/charts/helm/jetstack-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/jetstack-charts.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: jetstack-charts

--- a/cluster/base/flux-system/charts/helm/k8s-at-home-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/k8s-at-home-charts.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: k8s-at-home-charts

--- a/cluster/base/flux-system/charts/helm/kured-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/kured-charts.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: kured-charts

--- a/cluster/base/flux-system/charts/helm/longhorn-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/longhorn-charts.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: longhorn-charts

--- a/cluster/base/flux-system/charts/helm/metallb-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/metallb-charts.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: metallb-charts

--- a/cluster/base/flux-system/charts/helm/metrics-server-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/metrics-server-charts.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: metrics-server-charts

--- a/cluster/base/flux-system/charts/helm/minecraft-server-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/minecraft-server-charts.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: minecraft-server-charts

--- a/cluster/base/flux-system/charts/helm/minio-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/minio-charts.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: minio-charts

--- a/cluster/base/flux-system/charts/helm/nfs-subdir-external-provisioner-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/nfs-subdir-external-provisioner-charts.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: nfs-subdir-external-provisioner-charts

--- a/cluster/base/flux-system/charts/helm/node-feature-discovery-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/node-feature-discovery-charts.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: node-feature-discovery-charts

--- a/cluster/base/flux-system/charts/helm/prometheus-community-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/prometheus-community-charts.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: prometheus-community-charts

--- a/cluster/base/flux-system/charts/helm/rook-ceph-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/rook-ceph-charts.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: rook-ceph-charts

--- a/cluster/base/flux-system/charts/helm/stakater-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/stakater-charts.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: stakater-charts

--- a/cluster/base/flux-system/charts/helm/traefik-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/traefik-charts.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: traefik-charts

--- a/cluster/crds/metallb/crds.yaml
+++ b/cluster/crds/metallb/crds.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
   name: metallb-source
@@ -16,7 +16,7 @@ spec:
     # include crd directory
     !/config/crd
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: crds-metallb

--- a/tmpl/cluster/gotk-sync.yaml
+++ b/tmpl/cluster/gotk-sync.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
   name: flux-system
@@ -10,7 +10,7 @@ spec:
     branch: main
   url: ${BOOTSTRAP_GIT_REPOSITORY}
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: flux-system


### PR DESCRIPTION
## Summary
- migrate Flux GitRepository, HelmRepository, and Kustomization manifests from deprecated beta API versions to stable APIs
- keep the change limited to API version lines so the existing specs stay unchanged
- prepares the repo for the Flux v2.8.8 component upgrade PR (#137)

## Validation
- `/tmp/flux-v2.8.8/flux migrate -f . --version=2.8 --yes`
- `rg -n "apiVersion: (source|kustomize|helm|image|notification)\\.toolkit\\.fluxcd\\.io/(v1beta1|v1beta2|v2beta1|v2beta2)" . || true`
- `kubectl kustomize cluster/base/flux-system`
- `kubectl kustomize cluster/base/flux-system/charts/helm`
- `kubectl kustomize cluster/crds/metallb`
- `KUBECONFIG=/home/stephen/.kube/config /tmp/flux-v2.8.8/flux diff kustomization flux-system --path ./cluster/base --kustomization-file cluster/base/flux-system/gotk-sync.yaml`
- `KUBECONFIG=/home/stephen/.kube/config /tmp/flux-v2.8.8/flux check`
