### PR TITLE
chore(deps): upgrade modern apps to app-template v5

### DIFF
--- a/cluster/apps/default/atuin/helm-release.yaml
+++ b/cluster/apps/default/atuin/helm-release.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       # renovate: registryUrl=https://bjw-s-labs.github.io/helm-charts/
       chart: app-template
-      version: 4.6.2
+      version: 5.0.1
       sourceRef:
         kind: HelmRepository
         name: bjw-s-charts

--- a/cluster/apps/default/vikunja/helm-release.yaml
+++ b/cluster/apps/default/vikunja/helm-release.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       # renovate: registryUrl=https://bjw-s-labs.github.io/helm-charts/
       chart: app-template
-      version: 4.6.2
+      version: 5.0.1
       sourceRef:
         kind: HelmRepository
         name: bjw-s-charts

--- a/cluster/apps/observability/unpoller/helm-release.yaml
+++ b/cluster/apps/observability/unpoller/helm-release.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       # renovate: registryUrl=https://bjw-s-labs.github.io/helm-charts/
       chart: app-template
-      version: 4.6.2
+      version: 5.0.1
       sourceRef:
         kind: HelmRepository
         name: bjw-s-charts


### PR DESCRIPTION
Splits the safe app-template 4.6.2 to 5.0.1 upgrades out of the failed combined Renovate PR #175. These values do not use rawResources or Kubernetes API access, the two breaking areas in the v5 migration guide.