### PR TITLE
chore(media): stage app-template v5 migrations

### DIFF
--- a/cluster/apps/media/prowlarr/helm-release.yaml
+++ b/cluster/apps/media/prowlarr/helm-release.yaml
@@ -5,6 +5,7 @@ metadata:
   name: &app prowlarr
   namespace: media
 spec:
+  suspend: true
   dependsOn:
   - name: longhorn
     namespace: longhorn-system
@@ -13,7 +14,7 @@ spec:
     spec:
       # renovate: registryUrl=https://bjw-s-labs.github.io/helm-charts/
       chart: app-template
-      version: 0.2.2
+      version: 5.0.1
       sourceRef:
         kind: HelmRepository
         name: bjw-s-charts
@@ -26,23 +27,39 @@ spec:
     remediation:
       retries: 5
   values:
-    image:
-      repository: ghcr.io/onedr0p/prowlarr-nightly
-      tag: 1.33.0.4991
-    env:
-      TZ: "${TIMEZONE}"
-      PROWLARR__INSTANCE_NAME: Prowlarr
-      PROWLARR__PORT: &port 80
-      PROWLARR__LOG_LEVEL: info
+    controllers:
+      prowlarr:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/onedr0p/prowlarr-nightly
+              tag: 1.33.0.4991
+            env:
+              TZ: "${TIMEZONE}"
+              PROWLARR__INSTANCE_NAME: Prowlarr
+              PROWLARR__PORT: &port 80
+              PROWLARR__LOG_LEVEL: info
+            resources:
+              requests:
+                cpu: 10m
+                memory: 100Mi
+              limits:
+                memory: 500Mi
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
     service:
-      main:
+      app:
+        controller: *app
         ports:
           http:
             port: *port
     ingress:
-      main:
-        enabled: true
-        ingressClassName: traefik
+      app:
+        className: traefik
         annotations:
           cert-manager.io/cluster-issuer: letsencrypt-production
           traefik.ingress.kubernetes.io/router.entrypoints: websecure
@@ -50,23 +67,15 @@ spec:
           - host: &host "{{ .Release.Name }}.k8s.${SECRET_DOMAIN}"
             paths:
               - path: /
-                pathType: Prefix
+                service:
+                  identifier: app
+                  port: http
         tls:
           - hosts:
               - *host
             secretName: prowlarr-tls
-    podSecurityContext:
-      runAsUser: 568
-      runAsGroup: 568
-      fsGroup: 568
-      fsGroupChangePolicy: "OnRootMismatch"
     persistence:
       config:
-        enabled: true
         existingClaim: prowlarr-config
-    resources:
-      requests:
-        cpu: 10m
-        memory: 100Mi
-      limits:
-        memory: 500Mi
+        globalMounts:
+          - path: /config

--- a/cluster/apps/media/radarr/helm-release.yaml
+++ b/cluster/apps/media/radarr/helm-release.yaml
@@ -5,6 +5,7 @@ metadata:
   name: &app radarr
   namespace: media
 spec:
+  suspend: true
   dependsOn:
   - name: longhorn
     namespace: longhorn-system
@@ -13,7 +14,7 @@ spec:
     spec:
       # renovate: registryUrl=https://bjw-s-labs.github.io/helm-charts/
       chart: app-template
-      version: 0.2.2
+      version: 5.0.1
       sourceRef:
         kind: HelmRepository
         name: bjw-s-charts
@@ -26,24 +27,40 @@ spec:
     remediation:
       retries: 5
   values:
-    image:
-      repository: ghcr.io/onedr0p/radarr
-      tag: 5.20.1.9773
-    env:
-      TZ: "${TIMEZONE}"
-      RADARR__INSTANCE_NAME: Radarr
-      RADARR__LOG_LEVEL: info
-      RADARR__APPLICATION_URL: "https://movies.k8s.${SECRET_DOMAIN}"
-      RADARR__PORT: &port 80
+    controllers:
+      radarr:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/onedr0p/radarr
+              tag: 5.20.1.9773
+            env:
+              TZ: "${TIMEZONE}"
+              RADARR__INSTANCE_NAME: Radarr
+              RADARR__LOG_LEVEL: info
+              RADARR__APPLICATION_URL: "https://movies.k8s.${SECRET_DOMAIN}"
+              RADARR__PORT: &port 80
+            resources:
+              requests:
+                memory: 350Mi
+                cpu: 25m
+              limits:
+                memory: 500Mi
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
     service:
-      main:
+      app:
+        controller: *app
         ports:
           http:
             port: *port
     ingress:
-      main:
-        enabled: true
-        ingressClassName: traefik
+      app:
+        className: traefik
         annotations:
           cert-manager.io/cluster-issuer: letsencrypt-production
           hajimari.io/enable: "true"
@@ -53,33 +70,25 @@ spec:
           - host: &host "movies.k8s.${SECRET_DOMAIN}"
             paths:
               - path: /
-                pathType: Prefix
+                service:
+                  identifier: app
+                  port: http
         tls:
           - hosts:
               - *host
             secretName: radarr-tls
     persistence:
       config:
-        enabled: true
         existingClaim: *app
+        globalMounts:
+          - path: /config
       nas-nfs-media:
-        enabled: true
         type: nfs
         server: "172.16.10.145"
         path: /mnt/storage-x/media/plex/Movies
-        mountPath: /movies
+        globalMounts:
+          - path: /movies
       downloads:
-        enabled: true
-        mountPath: /downloads
         existingClaim: nzbget-downloads
-    podSecurityContext:
-      runAsUser: 1000
-      runAsGroup: 1000
-      fsGroup: 1000
-      fsGroupChangePolicy: OnRootMismatch
-    resources:
-      requests:
-        memory: 350Mi
-        cpu: 25m
-      limits:
-        memory: 500Mi
+        globalMounts:
+          - path: /downloads

--- a/cluster/apps/media/sonarr/helm-release.yaml
+++ b/cluster/apps/media/sonarr/helm-release.yaml
@@ -5,6 +5,7 @@ metadata:
   name: &app sonarr
   namespace: media
 spec:
+  suspend: true
   dependsOn:
   - name: longhorn
     namespace: longhorn-system
@@ -13,7 +14,7 @@ spec:
     spec:
       # renovate: registryUrl=https://bjw-s-labs.github.io/helm-charts/
       chart: app-template
-      version: 0.2.2
+      version: 5.0.1
       sourceRef:
         kind: HelmRepository
         name: bjw-s-charts
@@ -26,27 +27,43 @@ spec:
     remediation:
       retries: 5
   values:
-    image:
-      repository: ghcr.io/onedr0p/sonarr
-      tag: 4.0.14.2938
-    env:
-      TZ: "${TIMEZONE}"
-      SONARR__INSTANCE_NAME: Sonarr
-      SONARR__LOG_LEVEL: info
-      SONARR__APPLICATION_URL: "https://tv.k8s.${SECRET_DOMAIN}"
-      SONARR__PORT: &port 80
-    envFrom:
-      - secretRef:
-          name: *app
+    controllers:
+      sonarr:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/onedr0p/sonarr
+              tag: 4.0.14.2938
+            env:
+              TZ: "${TIMEZONE}"
+              SONARR__INSTANCE_NAME: Sonarr
+              SONARR__LOG_LEVEL: info
+              SONARR__APPLICATION_URL: "https://tv.k8s.${SECRET_DOMAIN}"
+              SONARR__PORT: &port 80
+            envFrom:
+              - secretRef:
+                  name: *app
+            resources:
+              requests:
+                memory: 350Mi
+                cpu: 25m
+              limits:
+                memory: 500Mi
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
     service:
-      main:
+      app:
+        controller: *app
         ports:
           http:
             port: *port
     ingress:
-      main:
-        enabled: true
-        ingressClassName: traefik
+      app:
+        className: traefik
         annotations:
           cert-manager.io/cluster-issuer: letsencrypt-production
           hajimari.io/enable: "true"
@@ -56,33 +73,25 @@ spec:
           - host: &host "tv.k8s.${SECRET_DOMAIN}"
             paths:
               - path: /
-                pathType: Prefix
+                service:
+                  identifier: app
+                  port: http
         tls:
           - hosts:
               - *host
             secretName: sonarr-tls
     persistence:
       config:
-        enabled: true
         existingClaim: *app
+        globalMounts:
+          - path: /config
       nfs-nas-media:
-        enabled: true
         type: nfs
         server: "172.16.10.145"
         path: /mnt/storage-x/TVShows
-        mountPath: /tv
+        globalMounts:
+          - path: /tv
       downloads:
-        enabled: true
-        mountPath: /downloads
         existingClaim: nzbget-downloads
-    podSecurityContext:
-      runAsUser: 1000
-      runAsGroup: 1000
-      fsGroup: 1000
-      fsGroupChangePolicy: OnRootMismatch
-    resources:
-      requests:
-        memory: 350Mi
-        cpu: 25m
-      limits:
-        memory: 500Mi
+        globalMounts:
+          - path: /downloads

--- a/cluster/apps/media/tautulli/helm-release.yaml
+++ b/cluster/apps/media/tautulli/helm-release.yaml
@@ -5,12 +5,13 @@ metadata:
   name: &app tautulli
   namespace: media
 spec:
+  suspend: true
   interval: 15m
   chart:
     spec:
       # renovate: registryUrl=https://bjw-s-labs.github.io/helm-charts/
       chart: app-template
-      version: 0.2.2
+      version: 5.0.1
       sourceRef:
         kind: HelmRepository
         name: bjw-s-charts
@@ -23,20 +24,36 @@ spec:
     remediation:
       retries: 5
   values:
-    image:
-      repository: ghcr.io/onedr0p/tautulli
-      tag: 2.15.1
-    env:
-      TZ: "${TIMEZONE}"
+    controllers:
+      tautulli:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/onedr0p/tautulli
+              tag: 2.15.1
+            env:
+              TZ: "${TIMEZONE}"
+            resources:
+              requests:
+                cpu: 10m
+                memory: 250Mi
+              limits:
+                memory: 500Mi
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
     service:
-      main:
+      app:
+        controller: *app
         ports:
           http:
             port: 8181
     ingress:
-      main:
-        enabled: true
-        ingressClassName: traefik
+      app:
+        className: traefik
         annotations:
           external-dns.home.arpa/enabled: "true"
           cert-manager.io/cluster-issuer: letsencrypt-production
@@ -45,23 +62,15 @@ spec:
           - host: &host "{{ .Release.Name }}.k8s.${SECRET_DOMAIN}"
             paths:
               - path: /
-                pathType: Prefix
+                service:
+                  identifier: app
+                  port: http
         tls:
           - hosts:
               - *host
             secretName: tautulli-tls
-    podSecurityContext:
-      runAsUser: 568
-      runAsGroup: 568
-      fsGroup: 568
-      fsGroupChangePolicy: "OnRootMismatch"
     persistence:
       config:
-        enabled: true
         existingClaim: *app
-    resources:
-      requests:
-        cpu: 10m
-        memory: 250Mi
-      limits:
-        memory: 500Mi
+        globalMounts:
+          - path: /config


### PR DESCRIPTION
Migrates the remaining app-template 0.2.2 media values to the 5.0.1 controller, service, ingress, persistence, security-context, and resource schemas. Releases are intentionally staged with spec.suspend=true so immutable Deployment selectors can be replaced and validated one workload at a time. Split from failed combined PR #175.